### PR TITLE
chore: Add `end_of_line` to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+end_of_line = lf
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -119,5 +119,10 @@ repos:
           && npm run all
           '
         language: system
-        files: ^src/|^package\.json$
+        files: |
+          (?x)
+            (^src/
+            |^package\.json$
+            |^tsconfig\.json$
+          )
         verbose: true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "esModuleInterop": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "newLine": "lf"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated editor configuration to standardize line endings across the project.
	- Expanded the scope of pre-commit hooks to include additional file types.
	- Adjusted TypeScript configuration for line ending conventions in output files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->