### PR TITLE
chore(linters): Make `yamlfmt` force lines to be <80 when possible

### DIFF
--- a/.github/workflows/stale-actions.yaml
+++ b/.github/workflows/stale-actions.yaml
@@ -21,15 +21,13 @@ jobs:
           stale-issue-label: stale
           stale-pr-label: stale
           stale-issue-message: >
-            This issue has been automatically marked as stale because it has been
-            open 30 days
-            with no activity. Remove stale label or comment or this issue will be
-            closed in 10 days
+            This issue has been automatically marked as stale because it has
+            been open 30 days with no activity. Remove stale label or comment
+            or this issue will be closed in 10 days
           stale-pr-message: >
             This PR has been automatically marked as stale because it has been
-            open 30 days
-            with no activity. Remove stale label or comment or this PR will be
-            closed in 10 days
+            open 30 days with no activity. Remove stale label or comment or
+            this PR will be closed in 10 days
           # Not stale if have this labels or part of milestone
           exempt-issue-labels: bug,wip,on-hold,auto-update
           exempt-pr-labels: bug,wip,on-hold

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,8 @@ jobs:
       - name: '[Verification] Negative test: Missing required image parameter'
         # It will not be able to create comment outside PR. result in main branch:
         # Not Found - https://docs.github.com/rest
-        if: always() && steps.pre-setup.outcome == 'success' && github.ref != 'refs/heads/main'
+        if: always() && steps.pre-setup.outcome == 'success' && github.ref !=
+          'refs/heads/main'
         shell: bash
         run: |
           error_message="${{ steps.missing-required.outputs.error }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,7 @@ repos:
           - --mapping=2
           - --sequence=4
           - --offset=2
-          - --width=100
+          - --width=75
           - --implicit_start
 
   - repo: https://github.com/adrienverge/yamllint.git

--- a/README.md
+++ b/README.md
@@ -34,9 +34,6 @@ name: Dive CI
 on:
  pull_request:
 
-permissions:
-  contents: read
-
 jobs:
   dive:
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced messaging in automated workflows to improve clarity of stale issue and pull request notifications.
  - Improved formatting of workflow conditionals and adjusted YAML formatting guidelines.

- **Documentation**
  - Updated documentation for the action setup by removing obsolete permission settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->