### PR TITLE
ci: skip comment steps in fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -458,9 +458,13 @@ jobs:
       # Runs at the end and only when all other tests pass, as it posts the
       # results as a comment on the PR
       - name: 'Params: always-comment with github-token'
-        # It will not be able to create comment outside PR. result in main branch:
-        # Not Found - https://docs.github.com/rest
-        if: github.ref != 'refs/heads/main'
+        id: always-comment-with-github-token
+        # Requires write access to post PR comments.
+        # Forks run with a read-only GITHUB_TOKEN and cannot write to the
+        # upstream repo, so this step is skipped for fork PRs.
+        if: >-
+          github.ref != 'refs/heads/main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./
         with:
           image: ${{ env.TEST_IMAGE }}
@@ -468,7 +472,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: '[Verification] Params: always-comment with github-token'
-        if: github.ref != 'refs/heads/main'
+        if: steps.always-comment-with-github-token.outcome != 'skipped'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -493,7 +497,10 @@ jobs:
 
       # Test collapse-inefficient-files-details feature enabled
       - name: 'Params: collapse-inefficient-files-details'
-        if: github.ref != 'refs/heads/main'
+        id: collapse-inefficient-enabled
+        if: >-
+          github.ref != 'refs/heads/main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./
         with:
           image: ${{ env.TEST_IMAGE }}
@@ -501,7 +508,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: '[Verification] Params: collapse-inefficient-files-details enabled'
-        if: github.ref != 'refs/heads/main'
+        if: steps.collapse-inefficient-enabled.outcome != 'skipped'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -545,7 +552,10 @@ jobs:
 
       # Test collapse-inefficient-files-details feature disabled
       - name: 'Params: collapse-inefficient-files-details disabled'
-        if: github.ref != 'refs/heads/main'
+        id: collapse-inefficient-disabled
+        if: >-
+          github.ref != 'refs/heads/main' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: ./
         with:
           image: ${{ env.TEST_IMAGE }}
@@ -554,7 +564,7 @@ jobs:
           collapse-inefficient-files-details: false
 
       - name: '[Verification] Params: collapse-inefficient-files-details disabled'
-        if: github.ref != 'refs/heads/main'
+        if: steps.collapse-inefficient-disabled.outcome != 'skipped'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What
<sub>This section was generated by AI.</sub>

- Add fork guard (`github.event.pull_request.head.repo.full_name == github.repository`) to the 3 steps that post PR comments (`always-comment with github-token`, `collapse-inefficient-files-details` enabled/disabled)
- Add `id` to each comment-posting step
- Update paired verification steps to use `steps.<id>.outcome != 'skipped'` instead of the main-branch guard, so both steps skip together in forks and on main

### Why

Fork PRs run with a read-only `GITHUB_TOKEN` — even with `permissions: pull-requests: write` declared, GitHub withholds write access to the upstream repo for untrusted fork code. This caused the `Params: always-comment with github-token` step to fail with:

```
Error: Resource not accessible by integration
```

### Assisted-by
<sub>Specific models used per commit are specified in the commit messages.</sub>
- Assisted-by: Sisyphus:claude-sonnet-4-6 opencode (8606400)